### PR TITLE
fixed a typo on lab7

### DIFF
--- a/public/partials/labs/lab7.html
+++ b/public/partials/labs/lab7.html
@@ -124,7 +124,7 @@ cd ttt_threads</pre>
               will run the rendezvous test and all 5 tests for the queue.
               <pre class = "terminal">make rende</pre>
               or
-              <pre class = "terminal">make testqeue</pre>
+              <pre class = "terminal">make testqueue</pre>
               will run the tests for only rendezvous or the queue.
               Similarly you can do
               <pre class = "terminal">make testqueue1</pre>


### PR DESCRIPTION
Was testqeue -- In the makefile for the lab it is testqueue. I've just changed the webpage to match the Makefile for the lab!

Cheers - Abhishek!